### PR TITLE
Use `@vercel/remix` package

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,6 +1,6 @@
-import handleRequest from "@vercel/remix-entry-server";
 import { RemixServer } from "@remix-run/react";
-import type { EntryContext } from "@remix-run/server-runtime";
+import { handleRequest } from "@vercel/remix";
+import type { EntryContext } from "@vercel/remix";
 
 export default function (
   request: Request,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction, LinksFunction } from '@remix-run/server-runtime';
+import type { MetaFunction, LinksFunction } from '@vercel/remix';
 
 import {
   Link,

--- a/app/routes/edge.tsx
+++ b/app/routes/edge.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs } from '@remix-run/server-runtime';
+import type { LoaderArgs } from '@vercel/remix';
 import { useLoaderData } from '@remix-run/react';
 
 export const config = { runtime: 'edge' };

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
-import { defer } from '@remix-run/server-runtime';
-import type { LoaderArgs } from '@remix-run/server-runtime';
+import { defer } from '@vercel/remix';
+import type { LoaderArgs } from '@vercel/remix';
 import { Await, useLoaderData } from '@remix-run/react';
 
 export const config = { runtime: 'edge' };

--- a/app/routes/node-streaming.tsx
+++ b/app/routes/node-streaming.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
-import { defer } from '@remix-run/node';
-import type { LoaderArgs } from '@remix-run/server-runtime';
+import { defer } from '@vercel/remix';
+import type { LoaderArgs } from '@vercel/remix';
 import { Await, useLoaderData } from '@remix-run/react';
 
 let isCold = true;

--- a/app/routes/node.tsx
+++ b/app/routes/node.tsx
@@ -1,4 +1,4 @@
-import type { LoaderArgs } from '@remix-run/server-runtime';
+import type { LoaderArgs } from '@vercel/remix';
 import { useLoaderData } from '@remix-run/react';
 
 let isCold = true;

--- a/package.json
+++ b/package.json
@@ -7,18 +7,15 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/node": "^1.14.0",
-    "@vercel/remix-entry-server": "^0.1.0",
-    "@remix-run/react": "^1.14.0",
-    "@remix-run/server-runtime": "^1.14.0",
-    "isbot": "^3.6.5",
+    "@remix-run/react": "^1.14.3",
+    "@vercel/remix": "1.14.3-patch.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "^1.14.0",
-    "@remix-run/eslint-config": "^1.14.0",
-    "@remix-run/serve": "^1.14.0",
+    "@remix-run/dev": "^1.14.3",
+    "@remix-run/eslint-config": "^1.14.3",
+    "@remix-run/serve": "^1.14.3",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "eslint": "^8.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,34 +1,28 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@remix-run/dev': ^1.14.0
-  '@remix-run/eslint-config': ^1.14.0
-  '@remix-run/node': ^1.14.0
-  '@remix-run/react': ^1.14.0
-  '@remix-run/serve': ^1.14.0
-  '@remix-run/server-runtime': ^1.14.0
+  '@remix-run/dev': ^1.14.3
+  '@remix-run/eslint-config': ^1.14.3
+  '@remix-run/react': ^1.14.3
+  '@remix-run/serve': ^1.14.3
   '@types/react': ^18.0.25
   '@types/react-dom': ^18.0.8
-  '@vercel/remix-entry-server': ^0.1.0
+  '@vercel/remix': 1.14.3-patch.1
   eslint: ^8.27.0
-  isbot: ^3.6.5
   react: ^18.2.0
   react-dom: ^18.2.0
   typescript: ^4.8.4
 
 dependencies:
-  '@remix-run/node': 1.14.0
-  '@remix-run/react': 1.14.0_biqbaboplfbrettd7655fr4n2y
-  '@remix-run/server-runtime': 1.14.0
-  '@vercel/remix-entry-server': 0.1.0_react@18.2.0
-  isbot: 3.6.5
+  '@remix-run/react': 1.14.3_biqbaboplfbrettd7655fr4n2y
+  '@vercel/remix': 1.14.3-patch.1_biqbaboplfbrettd7655fr4n2y
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
 
 devDependencies:
-  '@remix-run/dev': 1.14.0_@remix-run+serve@1.14.0
-  '@remix-run/eslint-config': 1.14.0_6phwajf43xwwgpkdgjffawkphy
-  '@remix-run/serve': 1.14.0
+  '@remix-run/dev': 1.14.3_@remix-run+serve@1.14.3
+  '@remix-run/eslint-config': 1.14.3_6phwajf43xwwgpkdgjffawkphy
+  '@remix-run/serve': 1.14.3
   '@types/react': 18.0.27
   '@types/react-dom': 18.0.10
   eslint: 8.33.0
@@ -1660,12 +1654,12 @@ packages:
       tslib: 2.5.0
     dev: true
 
-  /@remix-run/dev/1.14.0_@remix-run+serve@1.14.0:
-    resolution: {integrity: sha512-EG9kG/rGSRucer+g5PJQ8lSMLtJNVVCpxVMzHOciGPRXjPK3pg5acOuOksJGvdiqgFX9UO5itielQZ81ZBy6jA==}
+  /@remix-run/dev/1.14.3_@remix-run+serve@1.14.3:
+    resolution: {integrity: sha512-46mmwiA/k9YDkg0UrP90UB3azVVWRXw16NLHRSbZiaaYe8XgUkddEtBnH/nBp/IrVCtzUL3LObplUe5sFk5Z9Q==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
-      '@remix-run/serve': ^1.14.0
+      '@remix-run/serve': ^1.14.3
     peerDependenciesMeta:
       '@remix-run/serve':
         optional: true
@@ -1681,8 +1675,8 @@ packages:
       '@babel/types': 7.20.7
       '@esbuild-plugins/node-modules-polyfill': 0.1.4_esbuild@0.16.3
       '@npmcli/package-json': 2.0.0
-      '@remix-run/serve': 1.14.0
-      '@remix-run/server-runtime': 1.14.0
+      '@remix-run/serve': 1.14.3
+      '@remix-run/server-runtime': 1.14.3
       '@vanilla-extract/integration': 6.0.3
       arg: 5.0.2
       cacache: 15.3.0
@@ -1732,8 +1726,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@remix-run/eslint-config/1.14.0_6phwajf43xwwgpkdgjffawkphy:
-    resolution: {integrity: sha512-Q4IcYRuLmDEvgovbzsqftx/FPkJHgle24e6L331RsXt7CRHHFQ1DxHBscSac20O0hW5s4smQl/gjfx42VjMvRA==}
+  /@remix-run/eslint-config/1.14.3_6phwajf43xwwgpkdgjffawkphy:
+    resolution: {integrity: sha512-Yy4PYSvAehj31LmkDA+lS5yCPL1lR9O04gMIo0xwHT2o59pF4QU54lEAvJJH+9MI0byZUI/v9DoGz1oGIb44IA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^8.0.0
@@ -1768,36 +1762,21 @@ packages:
       - supports-color
     dev: true
 
-  /@remix-run/express/1.14.0_express@4.18.2:
-    resolution: {integrity: sha512-Kj7kVbj3f86TTbwE8kbSqHjLEzHJvs+cvYdlBEDrWsuXj1q5ciHs7Jjun6qSLrrOxCtEMqFXc6s530p67M1fiQ==}
+  /@remix-run/express/1.14.3_express@4.18.2:
+    resolution: {integrity: sha512-v3TT+zBFSnOiVTHNiLp5A783UVYyZYbePxmPhvoe9JwHCmzVDA9mfyxYgDl/8NPDtYS+dAPU7mQ+aE1M5MXc7g==}
     engines: {node: '>=14'}
     peerDependencies:
       express: ^4.17.1
     dependencies:
-      '@remix-run/node': 1.14.0
+      '@remix-run/node': 1.14.3
       express: 4.18.2
     dev: true
 
-  /@remix-run/node/1.12.0:
-    resolution: {integrity: sha512-WiyRTEQKTUTf3Z3ke5DOwx+fjCkeD8ilI9kbRws1bG3xfdugaDrV9ra76DOZcrYlmVwjwtKE3mVDSRFtiYTTMw==}
+  /@remix-run/node/1.14.3:
+    resolution: {integrity: sha512-Mq0wUtgJtGwMQEBr/8p9XpdPBm7N+lby5CEbW6IKV59UC9N3VMGY3snfrsphBCq3sNZfbhIpaDdu2W+8EoqfnQ==}
     engines: {node: '>=14'}
     dependencies:
-      '@remix-run/server-runtime': 1.12.0
-      '@remix-run/web-fetch': 4.3.2
-      '@remix-run/web-file': 3.0.2
-      '@remix-run/web-stream': 1.0.3
-      '@web3-storage/multipart-parser': 1.0.0
-      abort-controller: 3.0.0
-      cookie-signature: 1.2.0
-      source-map-support: 0.5.21
-      stream-slice: 0.1.2
-    dev: false
-
-  /@remix-run/node/1.14.0:
-    resolution: {integrity: sha512-TAm6AMAxFTccCAUIMki5VY+6vhBmItFvms1K+uTZc0z62ct0i1JEH+xl2POj6wB0UJhlq8IWchAZ41KKttPV1A==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@remix-run/server-runtime': 1.14.0
+      '@remix-run/server-runtime': 1.14.3
       '@remix-run/web-fetch': 4.3.2
       '@remix-run/web-file': 3.0.2
       '@remix-run/web-stream': 1.0.3
@@ -1807,8 +1786,8 @@ packages:
       source-map-support: 0.5.21
       stream-slice: 0.1.2
 
-  /@remix-run/react/1.14.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-zwir/r49WKST7afHBVCSeB7FtMiZXkRYaBBZld49WmUJcheo3BrXGiZRtSCLtBWqe1eSI5jbOoe6K4EHJ8etEA==}
+  /@remix-run/react/1.14.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-dvwIx+9ZdE/9LHe8Rjos9gEOdQFLvC0dojCnKlsUIwfGhyjKE4wOHfqS9mZcmKFCvOFDakcZDallLNGaj0mEYg==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16.8'
@@ -1821,21 +1800,16 @@ packages:
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
-  /@remix-run/router/1.3.1:
-    resolution: {integrity: sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw==}
-    engines: {node: '>=14'}
-    dev: false
-
   /@remix-run/router/1.3.3:
     resolution: {integrity: sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==}
     engines: {node: '>=14'}
 
-  /@remix-run/serve/1.14.0:
-    resolution: {integrity: sha512-lf/hEwogYgxqiNdRdEoAf6u2IJK8o0QmsC2EIqc6sHIHTL1X+kDw39m46ePAFY/wU/ymRUtD+dote+u3PCAczA==}
+  /@remix-run/serve/1.14.3:
+    resolution: {integrity: sha512-5So5+PtAaYZq3hc45snkCKIOh51Z45WvhHpRgB0ZsOuhUf6p9UAY9LQk7GRNvkcqL9LChE3LQ9O4gPqnUiZgpA==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
-      '@remix-run/express': 1.14.0_express@4.18.2
+      '@remix-run/express': 1.14.3_express@4.18.2
       compression: 1.7.4
       express: 4.18.2
       morgan: 1.10.0
@@ -1843,21 +1817,8 @@ packages:
       - supports-color
     dev: true
 
-  /@remix-run/server-runtime/1.12.0:
-    resolution: {integrity: sha512-7I0165Ns/ffPfCEfuiqD58lMderTn2s/sew1xJ34ONa21mG/7+5T7diHIgxKST8rS3816JPmlwSqUaHgwbmO6Q==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@remix-run/router': 1.3.1
-      '@types/cookie': 0.4.1
-      '@types/react': 18.0.27
-      '@web3-storage/multipart-parser': 1.0.0
-      cookie: 0.4.2
-      set-cookie-parser: 2.5.1
-      source-map: 0.7.4
-    dev: false
-
-  /@remix-run/server-runtime/1.14.0:
-    resolution: {integrity: sha512-qkqfT7DDwVzLICtJxMGthIU4T7DVtLy+oxKAzOi9eiCFlr3aWqV30YJ5Kq6r/kP8tighlnHbj1uEo41+WbD8uA==}
+  /@remix-run/server-runtime/1.14.3:
+    resolution: {integrity: sha512-qh8sxfLj/XW1u6rluN7yIgbvMCoKrVacYGUiPM7g0VHk8h8MlZGAIUfsWM45Poxo3X0uLhNuqqxMaPWldKawIQ==}
     engines: {node: '>=14'}
     dependencies:
       '@remix-run/router': 1.3.3
@@ -2250,13 +2211,16 @@ packages:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
     dev: true
 
-  /@vercel/remix-entry-server/0.1.0_react@18.2.0:
-    resolution: {integrity: sha512-ux1pcYvcPXAUXQuSH4fwNfkrzYYemFpdc3r4lF3L3PBE5doGhYDuBdTfXZpWl1M5zXi6VAbK6V6qkD33iZWGDA==}
+  /@vercel/remix/1.14.3-patch.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-TBI/FS77HYZqjbgeABi7Rbg7RVQ1YLHcXm4/zroV4zl0nVbcXM2jVR3SXm0EuQKze+NZ0p3VBUz4I/xocTvq0w==}
+    engines: {node: '>=14'}
     peerDependencies:
-      react: ^18.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
-      '@remix-run/node': 1.12.0
-      isbot: 3.6.5
+      '@remix-run/node': 1.14.3
+      '@remix-run/server-runtime': 1.14.3
+      isbot: 3.6.6
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -4654,8 +4618,8 @@ packages:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
 
-  /isbot/3.6.5:
-    resolution: {integrity: sha512-BchONELXt6yMad++BwGpa0oQxo/uD0keL7N15cYVf0A1oMIoNQ79OqeYdPMFWDrNhCqCbRuw9Y9F3QBjvAxZ5g==}
+  /isbot/3.6.6:
+    resolution: {integrity: sha512-98aGl1Spbx1led422YFrusDJ4ZutSNOymb2avZ2V4BCCjF3MqAF2k+J2zoaLYahubaFkb+3UyvbVDVlk/Ngrew==}
     engines: {node: '>=12'}
     dev: false
 


### PR DESCRIPTION
Replace usages of `@remix-run/node` / `@remix-run/server-runtime` / `@vercel/remix-entry-server` with our own `@vercel/remix` package.