### PR TITLE
parseVercelId to make it executable on localhost

### DIFF
--- a/app/parse-vercel-id.ts
+++ b/app/parse-vercel-id.ts
@@ -1,7 +1,8 @@
 export function parseVercelId(id: string | null) {
   const parts = id?.split(":").filter(Boolean);
   if (!parts) {
-    throw new Error('"x-vercel-id" header not present');
+    console.log('"x-vercel-id" header not present. Running on localhost?');
+    return { proxyRegion: "localhost", computeRegion:"localhost" }
   }
   const proxyRegion = parts[0];
   const computeRegion = parts[parts.length - 2];


### PR DESCRIPTION
Changed throw new Error to console.log in order to be able to execute it on localhost.  Returns the values  { proxyRegion: "localhost", computeRegion:"localhost" }

There is no vercel-id on localhost or?